### PR TITLE
Have GET /messages serve up topic in the response JSON

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -90,6 +90,7 @@ def messages_for_ids(message_ids: List[int],
     for message_id in message_ids:
         msg_dict = message_dicts[message_id]
         msg_dict.update({"flags": user_message_flags[message_id]})
+        msg_dict.update({"topic": msg_dict["subject"]})
         if message_id in search_fields:
             msg_dict.update(search_fields[message_id])
         # Make sure that we never send message edit history to clients


### PR DESCRIPTION
When fetching messages from the backend those objects serve up topic as a copy of subject.

Part of #6 

