### PR TITLE
fix: Focus was not set when writing a new topic in a pre-existing stream

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -205,14 +205,14 @@ function assert_hidden(sel) {
         private_message_recipient: 'bob@example.com'}), 'compose-textarea');
     assert.equal(get_focus_area('stream', {}), 'stream');
     assert.equal(get_focus_area('stream', {stream: 'fun'}),
-                 'subject');
+                 'topic');
     assert.equal(get_focus_area('stream', {stream: 'fun',
                                            subject: 'more'}),
                  'compose-textarea');
     assert.equal(get_focus_area('stream', {stream: 'fun',
                                            subject: 'more',
                                            trigger: 'new topic button'}),
-                 'subject');
+                 'topic');
 }());
 
 (function test_focus_in_empty_compose() {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -32,11 +32,11 @@ function hide_box() {
 function get_focus_area(msg_type, opts) {
     // Set focus to "Topic" when narrowed to a stream+topic and "New topic" button clicked.
     if (msg_type === 'stream' && opts.stream && ! opts.subject) {
-        return 'subject';
+        return 'topic';
     } else if ((msg_type === 'stream' && opts.stream)
                || (msg_type === 'private' && opts.private_message_recipient)) {
         if (opts.trigger === "new topic button") {
-            return 'subject';
+            return 'topic';
         }
         return 'compose-textarea';
     }


### PR DESCRIPTION
`get_focus_area` returned subject instead of topic even though the HTML ID tag was changed.

For requirement FR2.1
Closes #18 