### PR TITLE
refactor: same_recipient_as_before() use topic instead of subject

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -816,7 +816,7 @@ function test_raw_file_drop(raw_drop_func) {
         page_params.narrow_topic = 'testing';
 
         reset_jquery();
-        set_up_compose_start_mock({subject: 'testing'});
+        set_up_compose_start_mock({topic: 'testing'});
 
         compose.initialize();
 

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -97,7 +97,7 @@ function assert_hidden(sel) {
     global.narrow_state.set_compose_defaults = function () {
         var opts = {};
         opts.stream = 'stream1';
-        opts.subject = 'topic1';
+        opts.topic = 'topic1';
         return opts;
     };
 
@@ -207,10 +207,10 @@ function assert_hidden(sel) {
     assert.equal(get_focus_area('stream', {stream: 'fun'}),
                  'topic');
     assert.equal(get_focus_area('stream', {stream: 'fun',
-                                           subject: 'more'}),
+                                           topic: 'more'}),
                  'compose-textarea');
     assert.equal(get_focus_area('stream', {stream: 'fun',
-                                           subject: 'more',
+                                           topic: 'more',
                                            trigger: 'new topic button'}),
                  'topic');
 }());

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -144,7 +144,7 @@ function set_filter(operators) {
 
     var stream_and_subject = narrow_state.set_compose_defaults();
     assert.equal(stream_and_subject.stream, 'Foo');
-    assert.equal(stream_and_subject.subject, 'Bar');
+    assert.equal(stream_and_subject.topic, 'Bar');
 
     set_filter([['pm-with', 'foo@bar.com']]);
     var pm_test = narrow_state.set_compose_defaults();

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1030,7 +1030,7 @@ exports.initialize = function () {
 
     if (page_params.narrow !== undefined) {
         if (page_params.narrow_topic !== undefined) {
-            compose_actions.start("stream", {subject: page_params.narrow_topic});
+            compose_actions.start("stream", {topic: page_params.narrow_topic});
         } else {
             compose_actions.start("stream", {});
         }

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -160,7 +160,7 @@ function fill_in_opts_from_current_narrowed_view(msg_type, opts) {
     var default_opts = {
         message_type:     msg_type,
         stream:           '',
-        subject:          '',
+        topic:          '',
         private_message_recipient: '',
         trigger:          'unknown',
     };
@@ -308,7 +308,7 @@ exports.respond_to_message = function (opts) {
     } else {
         msg_type = message.type;
     }
-    exports.start(msg_type, {stream: stream, subject: topic,
+    exports.start(msg_type, {stream: stream, topic: topic,
                              private_message_recipient: pm_recipient,
                              replying_to_message: message,
                              trigger: opts.trigger});

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -176,7 +176,7 @@ function same_recipient_as_before(msg_type, opts) {
     return (compose_state.get_message_type() === msg_type) &&
             ((msg_type === "stream" &&
               opts.stream === compose_state.stream_name() &&
-              opts.subject === compose_state.topic()) ||
+              opts.topic === compose_state.topic()) ||
              (msg_type === "private" &&
               opts.private_message_recipient === compose_state.recipient()));
 }

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -31,7 +31,7 @@ function hide_box() {
 
 function get_focus_area(msg_type, opts) {
     // Set focus to "Topic" when narrowed to a stream+topic and "New topic" button clicked.
-    if (msg_type === 'stream' && opts.stream && ! opts.subject) {
+    if (msg_type === 'stream' && opts.stream && ! opts.topic) {
         return 'topic';
     } else if ((msg_type === 'stream' && opts.stream)
                || (msg_type === 'private' && opts.private_message_recipient)) {
@@ -194,7 +194,7 @@ exports.start = function (msg_type, opts) {
     // If we are invoked by a compose hotkey (c or C), do not assume that we know
     // what the message's topic or PM recipient should be.
     if (opts.trigger === "compose_hotkey") {
-        opts.subject = '';
+        opts.topic = '';
         opts.private_message_recipient = '';
     }
 
@@ -204,7 +204,7 @@ exports.start = function (msg_type, opts) {
     }
 
     compose_state.stream_name(opts.stream);
-    compose_state.topic(opts.subject);
+    compose_state.topic(opts.topic);
 
     // Set the recipients with a space after each comma, so it looks nice.
     compose_state.recipient(opts.private_message_recipient.replace(/,\s*/g, ", "));

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -85,7 +85,7 @@ exports.set_compose_defaults = function () {
     }
 
     if (single.has('topic')) {
-        opts.subject = single.get('topic');
+        opts.topic = single.get('topic');
     }
 
     if (single.has('pm-with')) {

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -142,7 +142,7 @@ exports.initialize = function reload__initialize() {
 
         // TODO: preserve focus
         compose_actions.start(vars.msg_type, {stream: vars.stream || '',
-                                      subject: vars.subject || '',
+                                      topic: vars.subject || '',
                                       private_message_recipient: vars.recipient || '',
                                       content: vars.msg || ''});
         if (send_now) {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is based on issue #20. Not sure if I actually need to refactor anything else. I guess the `opts`object will be refactored somewhere else? Need some feedback regarding that!

**Testing Plan:** <!-- How have you tested? -->
I ran all tests and it worked fine. However this might cause issues if the `opts` object isn't refactored as well.



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Closes #20
