### PR TITLE
refactor: Use topic in function names defined in narrow file.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -262,7 +262,7 @@ function stubbing(func_name_to_stub, test_function) {
     assert_mapping('k', 'navigate.up');
     assert_mapping('K', 'navigate.page_up');
     assert_mapping('s', 'narrow.by_recipient');
-    assert_mapping('S', 'narrow.by_subject');
+    assert_mapping('S', 'narrow.by_topic');
     assert_mapping('u', 'popovers.show_sender_info');
     assert_mapping('i', 'popovers.open_message_menu');
     assert_mapping(':', 'reactions.open_reactions_popover', true);

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -554,13 +554,13 @@ function render(template_name, args) {
         note: "You sent a message to a muted topic.",
         link_text: "Narrow to here",
         link_msg_id: "99",
-        link_class: "compose_notification_narrow_by_subject",
+        link_class: "compose_notification_narrow_by_topic",
     };
     var html = '<div  id="out-of-view-notification" class="notification-alert">';
     html += render('compose_notification', args);
     html += '</div>';
     global.write_handlebars_output("compose_notification", html);
-    var a = $(html).find("a.compose_notification_narrow_by_subject");
+    var a = $(html).find("a.compose_notification_narrow_by_topic");
     assert.equal(a.text(), "Narrow to here");
 }());
 
@@ -879,7 +879,7 @@ function render(template_name, args) {
     var last_message_html = $(html).next('.recipient_row').find('div.messagebox:last .message_content').html().trim();
     assert.equal(last_message_html, 'This is message <span class="highlight">two</span>.');
 
-    var highlighted_subject_word = $(html).find('a.narrows_by_subject .highlight').text();
+    var highlighted_subject_word = $(html).find('a.narrows_by_topic .highlight').text();
     assert.equal(highlighted_subject_word, 'two');
 
     global.write_handlebars_output("message_group", html);

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -287,13 +287,13 @@ $(function () {
         narrow.by_recipient(row_id, {trigger: 'message header'});
     });
 
-    $("#home").on("click", ".narrows_by_subject", function (e) {
+    $("#home").on("click", ".narrows_by_topic", function (e) {
         if (e.metaKey || e.ctrlKey) {
             return;
         }
         e.preventDefault();
         var row_id = get_row_id_for_narrowing(this);
-        narrow.by_subject(row_id, {trigger: 'message header'});
+        narrow.by_topic(row_id, {trigger: 'message header'});
     });
 
     // SIDEBARS

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -85,7 +85,7 @@ var keypress_mappings = {
     77: {name: 'toggle_mute', message_view_only: true}, // 'M'
     80: {name: 'narrow_private', message_view_only: true}, // 'P'
     82: {name: 'respond_to_author', message_view_only: true}, // 'R'
-    83: {name: 'narrow_by_subject', message_view_only: true}, //'S'
+    83: {name: 'narrow_by_topic', message_view_only: true}, //'S'
     86: {name: 'view_selected_stream', message_view_only: false}, //'V'
     99: {name: 'compose', message_view_only: true}, // 'c'
     100: {name: 'open_drafts', message_view_only: true}, // 'd'
@@ -445,7 +445,7 @@ exports.process_hotkey = function (e, hotkey) {
         if (exports.processing_text()) {
             return false;
         }
-        if (event_name === 'narrow_by_subject' && overlays.streams_open()) {
+        if (event_name === 'narrow_by_topic' && overlays.streams_open()) {
             subs.keyboard_sub();
             return true;
         }
@@ -682,8 +682,8 @@ exports.process_hotkey = function (e, hotkey) {
             return message_flags.toggle_starred(msg);
         case 'narrow_by_recipient':
             return do_narrow_action(narrow.by_recipient);
-        case 'narrow_by_subject':
-            return do_narrow_action(narrow.by_subject);
+        case 'narrow_by_topic':
+            return do_narrow_action(narrow.by_topic);
         case 'respond_to_author': // 'R': respond to author
             compose_actions.respond_to_message({reply_type: "personal", trigger: 'hotkey pm'});
             return true;

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -244,7 +244,7 @@ MessageListView.prototype = {
                     message_container.stream_url =
                         narrow.by_stream_uri(message_container.msg.stream);
                     message_container.topic_url =
-                        narrow.by_stream_subject_uri(message_container.msg.stream,
+                        narrow.by_stream_topic_uri(message_container.msg.stream,
                                                      message_container.msg.subject);
                 } else {
                     message_container.pm_with_url =

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -393,7 +393,7 @@ exports.by = function (operator, operand, opts) {
     exports.activate([{operator: operator, operand: operand}], opts);
 };
 
-exports.by_subject = function (target_id, opts) {
+exports.by_topic = function (target_id, opts) {
     // don't use current_msg_list as it won't work for muted messages or for out-of-narrow links
     var original = message_store.get(target_id);
     if (original.type !== 'stream') {
@@ -620,9 +620,9 @@ exports.by_stream_uri = function (stream) {
     return "#narrow/stream/" + hash_util.encodeHashComponent(stream);
 };
 
-exports.by_stream_subject_uri = function (stream, subject) {
+exports.by_stream_topic_uri = function (stream, topic) {
     return "#narrow/stream/" + hash_util.encodeHashComponent(stream) +
-           "/subject/" + hash_util.encodeHashComponent(subject);
+           "/subject/" + hash_util.encodeHashComponent(topic);
 };
 
 exports.by_message_uri = function (message_id) {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -338,7 +338,7 @@ function process_notification(notification) {
         notification_object.onclick = function () {
             notification_object.cancel();
             if (feature_flags.clicking_notification_causes_narrow) {
-                narrow.by_subject(message.id, {trigger: 'notification'});
+                narrow.by_topic(message.id, {trigger: 'notification'});
             }
             window.focus();
         };
@@ -359,7 +359,7 @@ function process_notification(notification) {
                     // by calling `window.focus()` as well as don't need to clear the
                     // notification since it is the default behavior in Firefox.
                     if (feature_flags.clicking_notification_causes_narrow) {
-                        narrow.by_subject(message.id, {trigger: 'notification'});
+                        narrow.by_topic(message.id, {trigger: 'notification'});
                     }
                 };
             } else {
@@ -581,7 +581,7 @@ exports.notify_local_mixes = function (messages) {
         }
 
         var link_msg_id = message.id;
-        var link_class = "compose_notification_narrow_by_subject";
+        var link_class = "compose_notification_narrow_by_topic";
         var link_text = "Narrow to " + get_message_header(message);
 
         exports.notify_above_composebox(reason, link_class, link_msg_id, link_text);
@@ -596,7 +596,7 @@ exports.notify_messages_outside_current_search = function (messages) {
             return;
         }
         exports.notify_above_composebox("Sent! Your recent message is outside the current search.",
-                                        "compose_notification_narrow_by_subject",
+                                        "compose_notification_narrow_by_topic",
                                         message.id,
                                         "Narrow to " + get_message_header(message));
     });
@@ -634,9 +634,9 @@ exports.reify_message_id = function (opts) {
 };
 
 exports.register_click_handlers = function () {
-    $('#out-of-view-notification').on('click', '.compose_notification_narrow_by_subject', function (e) {
+    $('#out-of-view-notification').on('click', '.compose_notification_narrow_by_topic', function (e) {
         var msgid = $(e.currentTarget).data('msgid');
-        narrow.by_subject(msgid, {trigger: 'compose_notification'});
+        narrow.by_topic(msgid, {trigger: 'compose_notification'});
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -87,7 +87,7 @@ exports.widget = function (parent_elem, my_stream_id) {
                 unread: num_unread,
                 is_zero: num_unread === 0,
                 is_muted: muting.is_topic_muted(my_stream_name, topic_name),
-                url: narrow.by_stream_subject_uri(my_stream_name, topic_name),
+                url: narrow.by_stream_topic_uri(my_stream_name, topic_name),
             };
             var li = $(templates.render('topic_list_item', topic_info));
             self.topic_items.set(topic_name, li);

--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -9,7 +9,7 @@
                 </div>
 
                 <span class="stream_topic">
-                    <div class="message_label_clickable narrows_by_subject">
+                    <div class="message_label_clickable narrows_by_topic">
                         {{topic}}
                     </div>
                 </span>

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -20,7 +20,7 @@
             {{! topic stuff }}
             <span class="stream_topic">
                 {{! topic link }}
-                <a class="message_label_clickable narrows_by_subject"
+                <a class="message_label_clickable narrows_by_topic"
                     href="{{topic_url}}"
                     title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;, topic &quot;__subject__&quot;{{/tr}}">
                     {{#if use_match_properties}}


### PR DESCRIPTION
Two functions in narrow.js had subject in their name:

* by_stream_subject_uri
* by_subject

They now include topic instead.

Also made changes in other files (and test files) that used these functions.

Closes #16 
