### PR TITLE
Refactor: Change local variables and method of using "subject" to "topic" in markdown.js

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -306,40 +306,40 @@ var bugdown_data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../zerver
     });
 }());
 
-(function test_subject_links() {
+(function test_topic_links() {
     var message = {type: 'stream', subject: "No links here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, []);
 
     message = {type: 'stream', subject: "One #123 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 1);
     assert.equal(message.subject_links[0], "https://trac.zulip.net/ticket/123");
 
     message = {type: 'stream', subject: "Two #123 #456 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 2);
     assert.equal(message.subject_links[0], "https://trac.zulip.net/ticket/123");
     assert.equal(message.subject_links[1], "https://trac.zulip.net/ticket/456");
 
     message = {type: 'stream', subject: "New ZBUG_123 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 1);
     assert.equal(message.subject_links[0], "https://trac2.zulip.net/ticket/123");
 
     message = {type: 'stream', subject: "New ZBUG_123 with #456 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 2);
     assert(message.subject_links.indexOf("https://trac2.zulip.net/ticket/123") !== -1);
     assert(message.subject_links.indexOf("https://trac.zulip.net/ticket/456") !== -1);
 
     message = {type: 'stream', subject: "One ZGROUP_123:45 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 1);
     assert.equal(message.subject_links[0], "https://zone_45.zulip.net/ticket/123");
 
     message = {type: "not-stream"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 0);
 }());
 

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -104,7 +104,7 @@ function insert_local_message(message_request, local_id) {
     message.local_id = local_id;
     message.locally_echoed = true;
     message.id = message.local_id;
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
 
     waiting_for_id[message.local_id] = message;
     waiting_for_ack[message.local_id] = message;

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -82,18 +82,18 @@ exports.apply_markdown = function (message) {
     message.is_me_message = exports.is_status_message(message.raw_content, message.content);
 };
 
-exports.add_subject_links = function (message) {
+exports.add_topic_links = function (message) {
     if (message.type !== 'stream') {
         message.subject_links = [];
         return;
     }
-    var subject = message.subject;
+    var topic = message.subject;
     var links = [];
     _.each(realm_filter_list, function (realm_filter) {
         var pattern = realm_filter[0];
         var url = realm_filter[1];
         var match;
-        while ((match = pattern.exec(subject)) !== null) {
+        while ((match = pattern.exec(topic)) !== null) {
             var link_url = url;
             var matched_groups = match.slice(1);
             var i = 0;


### PR DESCRIPTION
close #14 

Added this requirement in docs:

ID: FR (?)
Title: class markdown should be able to add link of topic to a message.
Description: class markdown contains method add_topic_links to add link of a topic to a message after received a message.
Priority: Low
Verifiability: (Tests for this can probably be found in markdown.js)
Code refactor: markdown.js, echo.js
Test refactor: markdown.js
Refactor content: change local variable and methods which use “subject” instead of “topic”.

